### PR TITLE
1->2 guide: Suggest checking for existing npx install

### DIFF
--- a/blog/Migration-to-Fable2.md
+++ b/blog/Migration-to-Fable2.md
@@ -19,6 +19,7 @@ During Fable 2 development, [Babel 7](https://babeljs.io/blog/2018/08/27/7.0.0) 
 
 1. Install [npx](https://github.com/zkat/npx#readme), this a CLI program allowing us to run npm packages.
 
+    - Maybe it came with node/npm: `npx --help`
     - For npm: `npm install -g npx`
     - For yarn: `yarn global add npx`
 


### PR DESCRIPTION
According to [npx's author][1], it's bundled starting with npm@5.2.0.
It certainly came with my npm 6.4.1.

[Grumblings about how github's web-based editor should remind you that commit subject lines should stand on their own...]

[1]: https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b