### PR TITLE
Really minor english fixes.

### DIFF
--- a/docsrc/communicate/js-from-fable.md
+++ b/docsrc/communicate/js-from-fable.md
@@ -18,9 +18,9 @@ The very first thing to do is add the library to our project. Since we always ha
 
 ### Type safety with Imports and Interfaces
 
-To use code from JS libraries first you need to import it into F#. For this Fables uses [ES2015 imports](https://developer.mozilla.org/en/docs/web/JavaScript/reference/statements/import), which can be later transformed to other JS module systems like `commonjs` or `amd` by [Babel](https://babeljs.io/docs/en/plugins#modules).
+To use code from JS libraries first you need to import it into F#. For this Fable uses [ES2015 imports](https://developer.mozilla.org/en/docs/web/JavaScript/reference/statements/import), which can be later transformed to other JS module systems like `commonjs` or `amd` by [Babel](https://babeljs.io/docs/en/plugins#modules).
 
-There are two ways to declare ES2015 imports in the Fable: by using either the **Import attribute** or the **import expressions**. The `ImportAttribute` can decorate members, types or modules and works as follows:
+There are two ways to declare ES2015 imports in Fable: by using either the **Import attribute** or the **import expressions**. The `ImportAttribute` can decorate members, types or modules and works as follows:
 
 ```fsharp
 // Namespace imports
@@ -216,7 +216,7 @@ The content of `Emit` will actually be parsed by [Babel](https://babeljs.io/) so
 
 #### Let's do it! Use Emit
 
-Now let's work with Emit and take a new example with the following `MyClass.js`:
+Now let's work with Emit and look at a new example with the following `MyClass.js`:
 
 ```js
 export default class MyClass {

--- a/docsrc/communicate/js-from-fable.md
+++ b/docsrc/communicate/js-from-fable.md
@@ -141,7 +141,7 @@ we could use the same method we used with `alert.js`:
   mylib.drawSmiley() // etc..
 ```
 
-or we could do the same things a little bit differently, by using the `importMember` helper function to directly map the js function to the F# function.
+or we could use the `importMember` helper function to directly map the js function to the F# function.
 
 ```fsharp
 open Fable.Core.JsInterop // needed to call interop tools


### PR DESCRIPTION
Hey, I'm learning about F# Js interop and, while reading this part, I've noticed some small (really small) typos.

There is one improvement that could be made (in my opinion) that I did not put into this PR, as it goes a bit beyond just fixing typos.

> or we could do the same things a little bit differently, by using the importMember helper function to directly map the js function to the F# function.

I would suggest shortening this to just say something like:

> or we could use the importMember helper function to directly map the js function to the F# function.

As the next sentence below will say that they're equivalent anyway (if the reader did not get this yet from the context).

> The result would be the same, but the philosophy (...)