### PR TITLE
Fix typo in fable-from-js.md

### DIFF
--- a/docsrc/communicate/fable-from-js.md
+++ b/docsrc/communicate/fable-from-js.md
@@ -111,7 +111,7 @@ myClass.Square(); // 25
 
 ## Functions: automatic uncurrying
 
-Fable will automatically uncurry functions in many situations: when they're passed as functions, when set as a record field... So in most cases you can use pass them to and from JS as if they were functions without curried arguments.
+Fable will automatically uncurry functions in many situations: when they're passed as functions, when set as a record field... So in most cases you can pass them to and from JS as if they were functions without curried arguments.
 
 ```fsharp
 let execute (f: int->int->int) x y =


### PR DESCRIPTION
~~As a side note, finding the source of https://fable.io/docs/communicate/fable-from-js.html is harder than it should be!~~

~~Maybe adding a link to the source file in the generated output would be a good idea?~~

EDIT: I'm dumb, I just now see there is a big `Edit` button at the top of the page :)