### PR TITLE
Fix layout shift while twitter feed loads

### DIFF
--- a/src/components/HomePage.fs
+++ b/src/components/HomePage.fs
@@ -10,9 +10,12 @@ open Util.Types
 open GlobalHelpers
 open Fable.Core
 open Fable.Core.JsInterop
+open Fable.React.Props
 
-let twitterFeed =
-  """<a class="twitter-timeline" data-lang="en" data-width="400" data-height="600" data-theme="light" href="https://twitter.com/FableCompiler?ref_src=twsrc%5Etfw">Tweets by FableCompiler</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>"""
+let twitterFeed (width, height) =
+  sprintf
+    """<a class="twitter-timeline" data-lang="en" data-width="%i" data-height="%i" data-theme="light" href="https://twitter.com/FableCompiler?ref_src=twsrc%%5Etfw">Tweets by FableCompiler</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>"""
+    width height
 
 let cardTexts =
   [
@@ -102,11 +105,16 @@ let renderBody (info: PageInfo) =
 
         Column.column [ Column.Width (Screen.All, Column.IsOneThird) ] [
           div [
+            let (width, height) = (400, 600)
             Style [
               Margin "10px auto"
               Width "fit-content"
+              Height height
+              
+              // hide placeholder link that gets pushed down temporarily before being removed
+              CSSProp.Overflow OverflowOptions.Hidden
             ]
-            DangerouslySetInnerHTML { __html = parseMarkdown twitterFeed }
+            DangerouslySetInnerHTML { __html = parseMarkdown (twitterFeed (width, height)) }
           ] []
         ]
       ]

--- a/src/components/HomePage.fs
+++ b/src/components/HomePage.fs
@@ -96,21 +96,19 @@ let renderBody (info: PageInfo) =
   div [Style [ CSSProp.Overflow OverflowOptions.Hidden ]] [
 
     Container.container [] [
-      Columns.columns [ Columns.IsVCentered ] [
-        Column.column [
-          Column.Width (Screen.All, Column.IsTwoThirds)
-        ] [
+      Columns.columns [ Columns.IsVCentered; Columns.CustomClass "homepage-header" ] [
+        div [ ] [
           Header.render()
         ]
 
-        Column.column [ Column.Width (Screen.All, Column.IsOneThird) ] [
+        div [ ] [
           div [
             let (width, height) = (400, 600)
             Style [
               Margin "10px auto"
               Width "fit-content"
               Height height
-              
+
               // hide placeholder link that gets pushed down temporarily before being removed
               CSSProp.Overflow OverflowOptions.Hidden
             ]

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -138,6 +138,34 @@ span.token.tag {
   //align-content: center;
 }
 
+.homepage-header {
+  > div {
+    padding: 0.75rem;
+  }
+
+  // The purpose of this is to show the embedded twitter timeline
+  // as a 1/3 column, but if it is blocked from loading, the first column (fable header)
+  // should take up the full space
+
+  > div:nth-child(1) {
+    padding-right: 0;
+    flex-basis: 66.66%;
+    flex-grow: 2;
+  }
+
+  > div:nth-last-child(1) {
+    padding-left: 0;
+
+    a.twitter-timeline {
+      display: none;
+    }
+
+    iframe {
+      align-self: center;
+    }
+  }
+}
+
 .fable-header {
   //   background: linear-gradient(to left, lighten($fable-blue, 20%), white);
   //   padding: 2rem 0;


### PR DESCRIPTION
There is currently a lot of layout shift moving content up and down as the large fable-logo and twitter feed load.
This fixes that by styling the twitter feed div with a fixed height.