### PR TITLE
Fixed community page link to Reddit F# sub

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -18,4 +18,4 @@ The community tend to congragate in the following forums:
 
 - [Fable Gitter](https://gitter.im/fable-compiler/Fable)
 - [F# Software Foundation Slack](https://fsharp.org/guides/slack/)
-- [F# Reddit](www.reddit.com/r/fsharp/)
+- [F# Reddit](https://www.reddit.com/r/fsharp/)


### PR DESCRIPTION
It originally pointed to https://fable.io/www.reddit.com/r/fsharp/ instead of https://www.reddit.com/r/fsharp/