### PR TITLE
Add Fable.Packages link + documentation on how to setup a Fable package to make it compatible

### DIFF
--- a/docs/docs/your-fable-project/author-a-fable-library.md
+++ b/docs/docs/your-fable-project/author-a-fable-library.md
@@ -3,7 +3,9 @@ title: Author a Fable library
 layout: standard
 ---
 
-To write a library that can be used in Fable you only need to fulfill a few conditions:
+## Requirements
+
+To write a library that can be used in Fable you need to fulfill a few conditions:
 
 - Don't use FSharp.Core/BCL APIs that are not [compatible with Fable](../dotnet/compatibility.html).
 - Keep a simple `.fsproj` file: don't use MSBuild conditions or similar.
@@ -18,7 +20,89 @@ The last point may sound complicated but it's only a matter of adding a couple o
 </ItemGroup>
 ```
 
-That's all it takes to make your library compatible with Fable! In order to publish the package to Nuget check [the Microsoft documentation](https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli) or alternatively you can also [use Fake](https://fake.build/dotnet-nuget.html#Creating-NuGet-packages).
+In order to publish the package to Nuget check [the Microsoft documentation](https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli) or alternatively you can also [use Fake](https://fake.build/dotnet-nuget.html#Creating-NuGet-packages).
+
+## Make your package discoverable
+
+[Fable.Packages](https://fable.io/packages/) is a tool making it easy for users to search for Fable packages. 
+
+To make your packages listed on Fable.Packages, you need to add some tags to your `.fsproj`.
+
+<ul class="textual-steps">
+
+<li>
+
+**All Fable** packages must have the `fable` tag.
+
+</li>
+
+<li>
+
+Specify what kind of package you are publishing.
+
+A fable package can be one of the following:
+
+- `fable-library`: A library that can be used in Fable
+
+    Examples of libraries could be [Fable.Promise](https://github.com/fable-compiler/fable-promise/), [Elmish](https://elmish.github.io/), [Thoth.Json](https://thoth-org.github.io//Thoth.Json/), [Feliz](https://zaid-ajaj.github.io/Feliz/)
+
+    <div></div> <!-- Force a space to improve visual -->
+
+- `fable-binding`: The package consist of a set of API to make a native library available
+
+    For example:
+    
+    - A package which makes an NPM package API available
+    - A package which makes the Browser API available
+    - A package which makes a cargo package API available
+
+</li>
+
+<li>
+
+Specify which targets are supported by your package.
+
+Choose one or more of the following tags:
+
+- `fable-dart`: Dart is supported by the package 
+- `fable-dotnet`: .NET is supported by the package 
+- `fable-javascript`: JavaScript is supported by the package 
+- `fable-python`: Python is supported by the package 
+- `fable-rust`: Rust is supported by the package 
+- `fable-all`: Package is compatible with all Fable targets.
+
+    :::warning
+    A package can only be compatible with all the target if it depends only packages that are also compatible with all the targets.
+
+    A package compatible with all the targets cannot be a binding as bindings are target specific.
+    :::
+
+Example:
+
+If your package support only JavaScript you need to use `fable-javascript`
+
+If your package support both JavaScript and Python, you need to use `fable-javascript` and `fable-python`
+
+</li>
+
+</ul>
+
+Examples:
+
+If your package is a binding which target JavaScript you need to write:
+
+```xml
+<PropertyGroup>
+<PackageTags>fable;fable-binding;fable-javascript</PackageTags>
+```
+
+If your package is a library which target JavaScript and Python you need to write:
+
+```xml
+<PropertyGroup>
+<PackageTags>fable;fable-library;fable-javascript;fable-python</PackageTags>
+</PropertyGroup>
+```
 
 ## Testing
 

--- a/nacara.config.json
+++ b/nacara.config.json
@@ -14,6 +14,10 @@
                 "pinned": true
             },
             {
+                "url": "/packages/",
+                "label": "Packages"
+            },
+            {
                 "url": "/repl/",
                 "label": "Try"
             },


### PR DESCRIPTION
@alfonsogarciacaro @ncave @dbrattli @Zaid-Ajaj @alexswan10k

Can you please review the `docs/docs/your-fable-project/author-a-fable-library.md` update?

This document serves 2 purposes:

1. It explain the implementation that has been choose for Fable.Packages
2. Serve as documentation for library authors to setup their packages