### PR TITLE
fix(docs): StringEnum doesn't exist

### DIFF
--- a/docs/docs/communicate/js-from-fable.md
+++ b/docs/docs/communicate/js-from-fable.md
@@ -471,7 +471,7 @@ By default, the compiled string will have the first letter lowered. If you want 
 ```fsharp
 open Fable.Core
 
-[<StringEnum>]
+[<StringEnumAttribute>]
 type MyStrings =
     | Vertical
     | [<CompiledName("Horizontal")>] Horizontal


### PR DESCRIPTION
I think `StringEnum` doesn't exist anymore? `StringEnumAttribute` seems to be correct now