### PR TITLE
Create dotnet/compatibility.md

### DIFF
--- a/docs/docs/dotnet/compatibility.md
+++ b/docs/docs/dotnet/compatibility.md
@@ -3,5 +3,10 @@ title: .NET compatibility
 layout: standard
 ---
 
-For compatibility with Javascrit and Typescript please see the [Javascript Compatibility](/docs/javascript/compatibility.html) section.
-For compatibility with Python see [Python Compatibility](/docs/python/compatibility.html)
+Please choose you target platform:
+
+- [JavaScript](/docs/javascript/compatibility.html)
+- [TypeScript](/docs/typescript/compatibility.html)
+- [Python](/docs/python/compatibility.html)
+<!-- - [Rust](/docs/rust/compatibility.html)
+- [Dart](/docs/dart/compatibility.html) -->

--- a/docs/docs/dotnet/compatibility.md
+++ b/docs/docs/dotnet/compatibility.md
@@ -1,0 +1,7 @@
+---
+title: .NET compatibility
+layout: standard
+---
+
+For compatibility with Javascrit and Typescript please see the [Javascript Compatibility](/docs/javascript/compatibility.html) section.
+For compatibility with Python see [Python Compatibility](/docs/python/compatibility.html)


### PR DESCRIPTION
This is a stand in for the currently broken URL on this page https://fable.io/docs/introduction/dotnet-users-read-this.html  as well as the warning Fable gives when trying to run it on non-compatibly code.