### PR TITLE
Upgrade Rust to Beta

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -63,7 +63,7 @@ F# is already used on the server for web and cloud apps, and it's also used quit
     </tr>
     <tr>
       <td>Rust</td>
-      <td>Alpha</td>
+      <td>Beta</td>
     </tr>
     <tr>
       <td>PHP</td>


### PR DESCRIPTION
According to https://github.com/fable-compiler/Fable/issues/2703#issuecomment-2564772993

Do you think Python can also be upgraded, to `Stable` in this case?