### PR TITLE
Add version tag to Beam docs

### DIFF
--- a/docs/docs/beam/build-and-run.md
+++ b/docs/docs/beam/build-and-run.md
@@ -3,6 +3,10 @@ title: Build and Run
 layout: standard
 ---
 
+<p class="tag is-info is-medium">
+    Added in v5.0.0-rc.1
+</p>
+
 ## Erlang/OTP Version
 
 Fable targets Erlang/OTP 25 or higher.

--- a/docs/docs/beam/compatibility.md
+++ b/docs/docs/beam/compatibility.md
@@ -5,6 +5,10 @@ toc:
   to: 4
 ---
 
+<p class="tag is-info is-medium">
+    Added in v5.0.0-rc.1
+</p>
+
 :::warning
 Beam target is in alpha meaning that breaking changes can happen between minor versions.
 :::

--- a/docs/docs/beam/features.md
+++ b/docs/docs/beam/features.md
@@ -5,6 +5,10 @@ toc:
   to: 4
 ---
 
+<p class="tag is-info is-medium">
+    Added in v5.0.0-rc.1
+</p>
+
 In this section, we will cover specific features of Fable when targeting the BEAM (Erlang).
 
 :::warning

--- a/docs/docs/getting-started/your-first-fable-project.md
+++ b/docs/docs/getting-started/your-first-fable-project.md
@@ -54,7 +54,6 @@ dotnet add package Fable.Core
 
 </li>
 
-
 <li>
 
 We can now call Fable to transpile our F# code to the desired target.
@@ -69,6 +68,7 @@ dotnet fable --lang typescript
 # If you want to transpile to Python
 dotnet fable --lang python
 ```
+
 :::info
 If you are switching between languages make sure to delete the `fable_modules` folder before invoking Fable again.
 :::
@@ -83,6 +83,7 @@ To go further look into the respective target documentation to have an example o
 - [TypeScript](/docs/getting-started/typescript.html)
 - [Python](/docs/getting-started/python.html)
 - [Rust](/docs/getting-started/rust.html)
+- [Beam](/docs/getting-started/beam.html)
 <!-- - [Dart](/docs/getting-started/dart.html)
 - [PHP](/docs/getting-started/php.html) -->
 


### PR DESCRIPTION
## Summary
- Add "Added in v5.0.0-rc.1" version tag to all three Beam documentation pages (features, build-and-run, compatibility)
- Add Beam link to the getting started guide's target list

🤖 Generated with [Claude Code](https://claude.com/claude-code)