### PR TITLE
Fix documentation for typed arrays default behavior

### DIFF
--- a/docs/docs/getting-started/cli.md
+++ b/docs/docs/getting-started/cli.md
@@ -146,7 +146,7 @@ Don't print any log during compilation
 </td>
 <td>
 
-Compile numeric arrays as JS typed arrays (default is true for JS, false for TS)
+Compile numeric arrays as JS typed arrays (default is true for JS and TS)
 </td>
 </tr>
 


### PR DESCRIPTION
this seems no longer true:
 
<img width="1092" height="481" alt="image" src="https://github.com/user-attachments/assets/232d43fe-088f-44e7-8be4-0166e7f7aee8" />


https://fable.io/repl/#?code=DYUwLgBAhhC8EG0A+BGA3AJiQXQFBA&html=Q&css=Q
